### PR TITLE
Feature/fix policy fragment to extract with global extractions (v1.4.0)

### DIFF
--- a/scripts/extractorHelper.ps1
+++ b/scripts/extractorHelper.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param (
     [string]$settingsFilePath = 'extractorSettings.template.json',
-    [string]$extractorBinaryPath = '../../tools/azure-api-management-devops-resource-kit/ArmTemplates.exe',
+    [string]$extractorBinaryPath = '../../tools/azure-api-management-devops-resource-kit/ApiManagementExtractor.exe',
     [string[]] $apis = @('device-meter-api-v10', 'game-play-api-v10', 'metrics-api-v10', 'game-api-v10')
 )
 

--- a/src/ApiManagementExtractor/ApiManagementExtractor.csproj
+++ b/src/ApiManagementExtractor/ApiManagementExtractor.csproj
@@ -7,7 +7,7 @@
         <LangVersion>latest</LangVersion>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>apim-templates</ToolCommandName>
-        <Version>1.3.0</Version>
+        <Version>1.4.0</Version>
         <RootNamespace>$(SolutionName).$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <DockerfileContext>..\..</DockerfileContext>

--- a/src/ApiManagementExtractor/Commands/Executors/ExtractorExecutor.cs
+++ b/src/ApiManagementExtractor/Commands/Executors/ExtractorExecutor.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
         readonly IOpenIdConnectProviderExtractor openIdConnectProviderExtractor;
         readonly IPolicyFragmentsExtractor policyFragmentsExtractor;
         readonly IApiReleaseExtractor apiReleaseExtractor;
- 
+
         public ExtractorExecutor(
             ILogger<ExtractorExecutor> logger,
             IDirectoryNameGeneratorFactory directoryNameGeneratorFactory,
@@ -504,7 +504,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
             this.RenameExistingParametersDirectory(baseFilesGenerationDirectory);
 
             await this.GenerateResourceParametersFile(baseFilesGenerationDirectory, apiTemplate?.TypedResources.ParametersFileName, apiTemplate, mainParametersTemplate);
-            await this.GenerateResourceParametersFile(baseFilesGenerationDirectory, this.extractorParameters.FileNames.GlobalServicePolicyParameters , policyTemplate, mainParametersTemplate);
+            await this.GenerateResourceParametersFile(baseFilesGenerationDirectory, this.extractorParameters.FileNames.GlobalServicePolicyParameters, policyTemplate, mainParametersTemplate);
             await this.GenerateResourceParametersFile(baseFilesGenerationDirectory, this.extractorParameters.FileNames.ApiVersionSetsParameters, apiVersionSetTemplate, mainParametersTemplate);
             await this.GenerateResourceParametersFile(baseFilesGenerationDirectory, this.extractorParameters.FileNames.ProductsParameters, productsTemplate, mainParametersTemplate);
             await this.GenerateResourceParametersFile(baseFilesGenerationDirectory, this.extractorParameters.FileNames.ProductAPIsParameters, productApisTemplate, mainParametersTemplate);
@@ -603,7 +603,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
                     this.extractorParameters, apiTemplateResources, null, apiVersionSetTemplateResources,
                     null, productApisTemplateResources, apiTagsTemplateResources, null,
                     null, null, null, null,
-                    null, null, null, null, policyFragmentsResources);
+                    null, null, null, null, null);
             }
             else if (this.extractorParameters.GenerateGlobalTemplates)
             {
@@ -611,7 +611,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
                     this.extractorParameters, null, policyTemplateResources, null,
                     productsTemplateResources, null, null, loggersTemplateResources,
                     backendsTemplateResources, authorizationServersTemplateResources, namedValuesTemplateResources, tagTemplateResources,
-                    groupTemplateResources, identityProviderTemplateResources, schemaTemplateResources, openIdConnectProviderResources, null);
+                    groupTemplateResources, identityProviderTemplateResources, schemaTemplateResources, openIdConnectProviderResources, policyFragmentsResources);
             }
 
 
@@ -923,7 +923,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
                     directory: baseFilesGenerationDirectory,
                     fileName: this.extractorParameters.FileNames.ApiManagementService);
             }
-            
+
             this.logger.LogInformation("Finished generation of identity providers template...");
             return apiManagementServiceTemplate;
         }
@@ -1091,7 +1091,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
                 {
                     // generate seperate folder for each API
                     string apiFileFolder = directoryNameGenerator.GetApiVersionAndRevisionFolder(apiRootFolder, apiName);
-                    
+
                     Directory.CreateDirectory(apiFileFolder);
                     await this.GenerateTemplates(apiFileFolder, singleApiName: apiName);
                 }
@@ -1199,7 +1199,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
                 revList.Add(apiRevisionName);
 
                 await this.GenerateTemplates(revFileFolder, singleApiName: apiRevisionName);
-                
+
                 if (generateSingleApiReleaseTemplate)
                 {
                     await this.GenerateApiReleaseTemplateAsync(apiRevisionName, revFileFolder);
@@ -1275,7 +1275,6 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
                 {
                     apiReleasesTemplate = await this.GenerateApiReleasesTemplateAsync(baseFilesGenerationDirectory);
                 }
-                policyFragmentTemplate = await this.GeneratePolicyFragmentsTemplateAsync(apiTemplate.TypedResources.GetAllPolicies(), baseFilesGenerationDirectory);
                 await this.GenerateGatewayApiTemplateAsync(singleApiName, multipleApiNames, baseFilesGenerationDirectory);
             }
 
@@ -1301,6 +1300,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
                 identityProviderTemplate = await this.GenerateIdentityProviderTemplateAsync(baseFilesGenerationDirectory);
                 openIdConnectProviderTemplate = await this.GenerateOpenIdConnectProviderTemplateAsync(baseFilesGenerationDirectory);
                 schemasTempate = await this.GenerateSchemasTemplateAsync(baseFilesGenerationDirectory);
+                var globalPolicies = new List<PolicyTemplateResource>() { globalServicePolicyTemplate.TypedResources.GlobalServicePolicy };
+                policyFragmentTemplate = await this.GeneratePolicyFragmentsTemplateAsync(globalPolicies, baseFilesGenerationDirectory);
                 await this.GenerateGatewayTemplateAsync(singleApiName, baseFilesGenerationDirectory);
                 if (this.extractorParameters.GenerateApiManagementServiceTemplate)
                 {
@@ -1395,11 +1396,11 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Commands.Executo
 
             // Generate folders based on all apiversionset
             var apiDictionary = new Dictionary<string, List<string>>();
-            
+
             foreach (var api in apis)
             {
                 string apiDisplayName = api.Properties.DisplayName;
-                
+
                 if (!apiDictionary.ContainsKey(apiDisplayName))
                 {
                     var apiVersionSet = new List<string>();

--- a/src/ApiManagementExtractor/Extractor/EntityExtractors/PolicyExtractor.cs
+++ b/src/ApiManagementExtractor/Extractor/EntityExtractors/PolicyExtractor.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
 {
     public class PolicyExtractor : IPolicyExtractor
     {
-        public const string EmptyPolicyFileResourcePath = "Microsoft.Azure.Management.ApiManagement.ArmTemplates.Resources.EmptyPolicyFile.xml";
+        public const string EmptyPolicyFileResourcePath = "ApiManagementExtractor.ApiManagementExtractor.Resources.EmptyPolicyFile.xml";
         public const string PoliciesDirectoryName = "policies";
         public const string OperationPoliciesDirectoryName = "operations";
         public const string ProductPoliciesDirectoryName = "products";
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
 
         public const string ProductPolicyFileNameFormat = "{0}.xml";
         public const string ApiPolicyFileNameFormat = "{0}.xml";
-        public const string ApiOperationPolicyFileNameFormat =  "{0}-{1}.xml";
+        public const string ApiOperationPolicyFileNameFormat = "{0}-{1}.xml";
 
         readonly ILogger<PolicyExtractor> logger;
         readonly IPolicyClient policyClient;
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
         }
 
         public async Task<PolicyTemplateResource> GenerateApiPolicyResourceAsync(
-            string apiName, 
+            string apiName,
             string baseFilesGenerationDirectory,
             ExtractorParameters extractorParameters)
         {
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
             productPolicy.ApiVersion = GlobalConstants.ApiVersion;
             productPolicy.Scale = null;
             productPolicy.DependsOn = productResourceId;
-            
+
             // due to legacy reasons, providing empty `policyXmlBaseUrl = ""` is recognized as a boolean parameter 
             // telling that it is needed to provide a policy Xml file
             if (extractorParameters.PolicyXMLBaseUrl is not null)
@@ -274,7 +274,8 @@ namespace Microsoft.Azure.Management.ApiManagement.ArmTemplates.Extractor.Entity
         }
 
         static string GetEmptyPolicyFileContents()
-        {   var assembly = Assembly.GetExecutingAssembly();
+        {
+            var assembly = Assembly.GetExecutingAssembly();
             using (Stream stream = assembly.GetManifestResourceStream(EmptyPolicyFileResourcePath))
             {
                 using (StreamReader reader = new StreamReader(stream))


### PR DESCRIPTION
This pull request includes several updates to the API Management Extractor tool, focusing on versioning, resource naming, and the handling of policy fragments. The most significant changes involve updating the binary name, incrementing the tool version, correcting resource paths, and modifying how policy fragments are generated and passed between templates.

**Versioning and Binary Updates**

* Changed the default extractor binary path in `extractorHelper.ps1` from `ArmTemplates.exe` to `ApiManagementExtractor.exe` to reflect the correct executable name.
* Updated the version of the `ApiManagementExtractor` tool from `1.3.0` to `1.4.0` in the project file.

**Resource and Path Corrections**

* Updated the `EmptyPolicyFileResourcePath` constant in `PolicyExtractor.cs` to use the correct namespace and resource path for the embedded empty policy file.

**Policy Fragment Generation and Handling**

* Changed the logic for generating policy fragments: now, when generating global templates, policy fragments are created using only the global service policy, rather than all policies, ensuring more accurate template output. [[1]](diffhunk://#diff-af65dba9f3704b9c56df81c84e890a41455b850933b9b23b42b81ec063b38f66L1278) [[2]](diffhunk://#diff-af65dba9f3704b9c56df81c84e890a41455b850933b9b23b42b81ec063b38f66R1303-R1304)
* Adjusted the parameters passed to `GenerateMasterTemplateAsync` to ensure policy fragments are included in the correct template scenarios, fixing a mismatch in the previous implementation.

**Minor Code Quality Improvements**

* Minor formatting improvements for readability in `PolicyExtractor.cs`.